### PR TITLE
fix: run push tests and security checks only on branches, excluding tags

### DIFF
--- a/.github/workflows/security-check.yaml
+++ b/.github/workflows/security-check.yaml
@@ -1,6 +1,9 @@
 name: Security check
 
-on: push
+on:
+  push:
+    branches:
+      - "**"
 
 env:
   FAKE_DOCKER_USERNAME: mydockerhubusername

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,9 @@
 name: Test
 
-on: push
+on:
+  push:
+    branches:
+      - "**"
 
 env:
   FAKE_DOCKER_USERNAME: mydockerhubusername


### PR DESCRIPTION
The fix involves running tests and security checks on all branches, excluding tags.